### PR TITLE
Several improvements

### DIFF
--- a/.github/workflows/preflight-summary.yml
+++ b/.github/workflows/preflight-summary.yml
@@ -57,11 +57,13 @@ jobs:
             cat {pylint,black,isort,bandit}-report.md > linter-reports.md 2>/dev/null || true
             if [[ -s linter-reports.md ]]; then
               printf "### Linter reports\n"
-              # Max size of comments on GitHub is 64KB. If the reports > 54KB, don't post them
-              if [[ $(stat --format=%s linter-reports.md) -gt 55296 ]]; then
-                printf "The reports are too big to be posted here.\n"
-              else
+              # Max size of comments on GitHub is 64KB. Don't post reports if they don't fit.
+              if awk '{sum += $1} END {exit sum > (62*1024)}' \
+                  <<< $(stat --format=%s test-summary.md code-coverage-results.md linter-reports.md)
+              then
                 cat linter-reports.md
+              else
+                printf "The reports are too big to be posted here.\n"
               fi
             fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM almalinux:9 as sign-file
+FROM almalinux/9-base:latest as sign-file
 
 RUN <<EOT
   set -ex
@@ -13,7 +13,7 @@ RUN <<EOT
   set -ex
   python3 -m ensurepip
   pip3 install .
-  rm setup.py
+  rm -rf setup.py ~/.cache/pip
 EOT
 
 
@@ -23,5 +23,5 @@ COPY requirements-tests.txt .
 RUN <<EOT
   set -ex
   pip3 install -r requirements-tests.txt
-  rm requirements-tests.txt
+  rm -rf requirements-tests.txt ~/.cache/pip
 EOT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,14 +3,14 @@ profile = "black"
 split_on_trailing_comma = true
 
 [tool.black]
-line-length = 120
+line-length = 80
 skip-string-normalization = true
 # see https://black.readthedocs.io/en/stable/the_black_code_style/future_style.html#preview-style
 preview = true
 enable-unstable-feature = ["hug_parens_with_braces_and_square_brackets"]
 
 [tool.pylint]
-max-line-length = 120
+max-line-length = 80
 
 # Minimum line length for functions/classes that require docstrings
 docstring-min-length = 50

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,5 @@
 pytest==8.1.1
-pytest-cov==4.1.0
+pytest-cov==5.0.0
 pyfakefs==5.3.5
 
 # Linters


### PR DESCRIPTION
- The preflight-summary GH workflow: don't post linter reports if they don't fit into the comment size limit
- Dockerfile: remove pip's cache in `~/.cache/pip`
- Use `line length = 88 chars` for Pylint and Black