### PR TITLE
Add missing sentry dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,6 @@ setup(
         'databases == 0.6.1',
         'bcrypt == 4.0.1',
         'pyjwt == 2.4.0',
+        'sentry-sdk == 2.22.0',
     ]
 )


### PR DESCRIPTION
Sentry was introduced in
https://github.com/AlmaLinux/albs-sign-file/pull/21 without adding the dependency.