### PR TITLE
fix: pydantic v2 and dependency compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         'SQLAlchemy >= 1.4.42, < 3.0',
         'bcrypt >= 4.0.1',
         'pyjwt >= 2.4.0',
+        'pydantic-settings >= 2.0.0',
         'sentry-sdk >= 2.22.0',
         'psycopg2-binary >= 2.9.3',
         'alembic >= 1.13.1',

--- a/sign/api/schema.py
+++ b/sign/api/schema.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from pydantic import BaseModel
 
@@ -15,7 +15,7 @@ class TokenResponse(BaseModel):
 
 
 class UserSchema(BaseModel):
-    user_id: str
+    user_id: Union[str, int]
     email: str
 
 

--- a/sign/config.py
+++ b/sign/config.py
@@ -2,7 +2,8 @@ import logging
 import os
 from typing import Dict, List, Optional
 
-from pydantic import BaseSettings, Field
+from pydantic import Field
+from pydantic_settings import BaseSettings
 
 logger = logging.getLogger(__name__)
 
@@ -304,6 +305,10 @@ def create_settings() -> Settings:
     for env_var, field_name in env_mapping.items():
         if env_var in os.environ:
             flat_config[field_name] = os.environ[env_var]
+
+    if 'SF_PGP_KEYS_ID' in os.environ:
+        import json
+        flat_config['pgp_keys'] = json.loads(os.environ['SF_PGP_KEYS_ID'])
 
     return Settings(**flat_config)
 

--- a/sign/db/helpers.py
+++ b/sign/db/helpers.py
@@ -1,7 +1,7 @@
 import re
 from contextlib import contextmanager
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
 from sign.auth.hash import get_hash
@@ -116,7 +116,7 @@ def db_is_connected() -> bool:
     try:
         with engine.connect() as conn:
             # Execute a simple query to verify connection
-            result = conn.execute("SELECT 1 as health_check")
+            result = conn.execute(text("SELECT 1 as health_check"))
             result.fetchone()
             return True
     except Exception:

--- a/sign/pgp/pgp.py
+++ b/sign/pgp/pgp.py
@@ -38,8 +38,8 @@ class PGP:
         self.tmp_dir = tmp_dir
         self.__pass_db.ask_for_passwords()
         self.__syslog = SysLog(tag_name=settings.service)
-        # Semaphore to control GPG operations and agent restarts
-        self.__gpg_semaphore = asyncio.Semaphore(1)
+        # Semaphore created lazily to avoid event loop issues in threads
+        self.__gpg_semaphore = None
 
     def list_keys(self):
         return self.__gpg.list_keys()
@@ -159,6 +159,8 @@ class PGP:
             ]
 
             # Use semaphore to protect GPG operation and agent restart
+            if self.__gpg_semaphore is None:
+                self.__gpg_semaphore = asyncio.Semaphore(1)
             async with self.__gpg_semaphore:
                 out, status = pexpect.run(
                     command=' '.join(sign_cmd.formulate()),

--- a/start.py
+++ b/start.py
@@ -7,6 +7,5 @@ if __name__ == "__main__":
         port=8000,
         reload=False,
         log_level="debug",
-        debug=True,
         workers=4,
     )


### PR DESCRIPTION
## Summary

Fresh Docker builds fail on startup due to unpinned dependencies pulling breaking versions. Fixes all 6 issues from #63.

- Import `BaseSettings` from `pydantic-settings`, add as explicit dependency
- Remove deprecated `debug` parameter from `uvicorn.run()`
- Wrap raw SQL with `text()` for SQLAlchemy 2.0
- Accept `Union[str, int]` for `UserSchema.user_id` — pydantic v2 no longer coerces types
- Create `asyncio.Semaphore` lazily in PGP class to avoid thread/event loop error
- Add missing `SF_PGP_KEYS_ID` to env var mapping, lost during KMS refactor

Fixes: https://github.com/AlmaLinux/albs-sign-file/issues/63

## Test plan

- [x] `pytest` passes (2/2)
- [x] Service starts on fresh build with SQLite
- [x] Token endpoint returns 200
- [x] Sign endpoint returns 200
- [x] End-to-end test from albs-web-server `test_repomd_signer` passes