### PR TITLE
feat: support zstd-compressed uploads on /sign and /sign-batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,93 @@ if __name__ == '__main__':
     print(sign_file())
 ```
 
+## Upload compressed payloads (optional)
+
+Both `/sign` and `/sign-batch` accept an optional `compression` form field. When
+set, the server streams the upload through a decompressor before signing, which
+can significantly reduce the amount of data sent over the wire for
+compressible files. The server still enforces `SF_MAX_UPLOAD_BYTES` against the
+**decompressed** size, and the returned signature is computed over the
+decompressed contents (so `gpg --verify` is run against the original file, not
+the compressed blob).
+
+| Value  | Behavior                                  |
+|--------|-------------------------------------------|
+| _omitted_ / empty | No decompression (default)     |
+| `zstd` | Body is zstd-compressed; server streams-decompresses on read |
+
+Unsupported values return HTTP 400.
+
+### curl example
+
+Compress the file with `zstd` first, then upload it together with
+`compression=zstd`:
+
+```bash
+zstd -3 my-file -o my-file.zst
+
+curl -X POST \
+  'http://localhost:8000/sign?keyid=AAAA1111BBBB2222' \
+  -H "Authorization: Bearer $TOKEN" \
+  -F 'compression=zstd' \
+  -F 'file=@my-file.zst;type=application/octet-stream' \
+  > my-file.asc
+
+gpg --verify my-file.asc my-file   # verifies against the ORIGINAL file
+```
+
+### Python example
+
+```python
+import requests
+import zstandard
+from urllib.parse import urljoin
+
+BASE_URL = 'http://localhost:8000'
+KEYID = 'AAAA1111BBBB2222'
+TOKEN = '...'  # from /token
+
+def sign_compressed(path: str) -> str:
+    with open(path, 'rb') as fh:
+        compressed = zstandard.ZstdCompressor(level=3).compress(fh.read())
+
+    response = requests.post(
+        urljoin(BASE_URL, '/sign'),
+        headers={'Authorization': f'Bearer {TOKEN}'},
+        params={'keyid': KEYID},
+        data={'compression': 'zstd'},
+        files={'file': (path + '.zst', compressed)},
+    )
+    response.raise_for_status()
+    return response.text
+```
+
+For very large files, prefer **streaming** zstd compression to avoid loading the
+whole file into memory:
+
+```python
+import io, zstandard, requests
+
+def stream_compressed(path: str) -> bytes:
+    buf = io.BytesIO()
+    cctx = zstandard.ZstdCompressor(level=3)
+    with open(path, 'rb') as src, cctx.stream_writer(buf, closefd=False) as out:
+        for chunk in iter(lambda: src.read(1024 * 1024), b''):
+            out.write(chunk)
+    return buf.getvalue()
+```
+
+The same `compression=zstd` field works with `/sign-batch` — every file in the
+multipart must be zstd-compressed (the flag is per-request, not per-file).
+
+### When compression helps
+
+- **Text-like files** (configs, scripts, manifests, repodata): typically
+  compresses to 15–25% of the original — large win on the wire.
+- **Already-compressed files** (RPMs, `.gz`, `.xz`, `.zst`, images, most
+  binaries): roughly the same size or marginally smaller — small CPU cost for
+  no real benefit. Don't set `compression` for those.
+
 ## Sign file with clear signature
 ### Request
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         'psycopg2-binary >= 2.9.3',
         'alembic >= 1.13.1',
         'PyYAML >= 6.0',
+        'zstandard >= 0.22.0',
     ],
     extras_require={
         'kms': [

--- a/sign/api/routes.py
+++ b/sign/api/routes.py
@@ -1,7 +1,7 @@
 import logging
 from typing import List
 
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
 from fastapi.responses import PlainTextResponse
 
 from sign.api.dependencies import get_backend, get_current_user
@@ -19,6 +19,7 @@ from sign.db.helpers import get_user
 from sign.db.models import User
 from sign.errors import FileTooBigError, UserNotFoundError
 from sign.signing.backend import SigningBackend
+from sign.utils.compression import SUPPORTED_COMPRESSIONS, maybe_wrap
 
 router = APIRouter()
 
@@ -41,6 +42,7 @@ async def sign(
     file: UploadFile,
     sign_type: str = 'detach-sign',
     sign_algo: str = 'SHA256',
+    compression: str = Form(default=''),
     user: User = Depends(get_current_user),
     backend: SigningBackend = Depends(get_backend),
 ) -> str:
@@ -49,10 +51,18 @@ async def sign(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f'key {keyid} does not exist',
         )
+    if compression and compression not in SUPPORTED_COMPRESSIONS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f'unsupported compression: {compression}; '
+                f'supported: {", ".join(SUPPORTED_COMPRESSIONS)}'
+            ),
+        )
     try:
         answer = await backend.sign(
             keyid,
-            file,
+            maybe_wrap(file, compression or None),
             detach_sign=sign_type == 'detach-sign',
             digest_algo=sign_algo,
         )
@@ -75,6 +85,7 @@ async def sign_batch(
     files: List[UploadFile] = File(...),
     sign_type: str = 'detach-sign',
     sign_algo: str = 'SHA256',
+    compression: str = Form(default=''),
     user: User = Depends(get_current_user),
     backend: SigningBackend = Depends(get_backend),
 ) -> BatchSignResponse:
@@ -109,15 +120,26 @@ async def sign_batch(
             detail=f'key {keyid} does not exist',
         )
 
+    if compression and compression not in SUPPORTED_COMPRESSIONS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f'unsupported compression: {compression}; '
+                f'supported: {", ".join(SUPPORTED_COMPRESSIONS)}'
+            ),
+        )
+
     logging.info(
         "user %s initiated batch signing of %d files with key %s",
         user.email, len(files), keyid,
     )
 
+    wrapped = [maybe_wrap(f, compression or None) for f in files]
+
     try:
         results_data = await backend.sign_batch(
             keyid=keyid,
-            files=files,
+            files=wrapped,
             detach_sign=sign_type == 'detach-sign',
             digest_algo=sign_algo,
         )

--- a/sign/utils/compression.py
+++ b/sign/utils/compression.py
@@ -1,0 +1,75 @@
+from typing import Optional
+
+import zstandard
+from fastapi import UploadFile
+
+
+SUPPORTED_COMPRESSIONS = ('zstd',)
+
+
+class DecompressingUploadFile:
+    """Wraps an UploadFile and streams zstd decompression on read().
+
+    Proxies the subset of the UploadFile interface used by signing
+    backends: async ``read(size)``, ``filename``, and ``file.close()``.
+    """
+
+    def __init__(self, upload_file: UploadFile):
+        self._upload = upload_file
+        self._dctx = zstandard.ZstdDecompressor()
+        self._dobj = self._dctx.decompressobj()
+        self._buffer = bytearray()
+        self._upstream_done = False
+
+    @property
+    def filename(self) -> Optional[str]:
+        return self._upload.filename
+
+    @property
+    def file(self):
+        return self._upload.file
+
+    async def read(self, size: int = -1) -> bytes:
+        # Pull from upstream and feed decompressor until we have enough
+        # decompressed bytes (or upstream is exhausted).
+        while not self._upstream_done and (
+            size < 0 or len(self._buffer) < size
+        ):
+            chunk = await self._upload.read(size if size > 0 else 1024 * 1024)
+            if not chunk:
+                self._upstream_done = True
+                # Flush any remaining bytes from the decompressor
+                tail = self._dobj.flush()
+                if tail:
+                    self._buffer.extend(tail)
+                break
+            try:
+                decompressed = self._dobj.decompress(chunk)
+            except zstandard.ZstdError as exc:
+                raise ValueError(
+                    f'invalid zstd stream: {exc}'
+                ) from exc
+            if decompressed:
+                self._buffer.extend(decompressed)
+
+        if size < 0 or size >= len(self._buffer):
+            out = bytes(self._buffer)
+            self._buffer.clear()
+            return out
+
+        out = bytes(self._buffer[:size])
+        del self._buffer[:size]
+        return out
+
+
+def maybe_wrap(
+    upload_file: UploadFile,
+    compression: Optional[str],
+) -> UploadFile:
+    if not compression:
+        return upload_file
+    if compression not in SUPPORTED_COMPRESSIONS:
+        raise ValueError(
+            f'unsupported compression: {compression}'
+        )
+    return DecompressingUploadFile(upload_file)  # type: ignore[return-value]


### PR DESCRIPTION
Add an optional `compression` form field that lets clients zstd-compress file payloads before upload. The server streams decompression through a thin UploadFile wrapper, so existing backends are unchanged and `max_upload_bytes` still bounds the decompressed size.