### PR TITLE
feat: fetch GPG passphrases from Bitwarden vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,48 @@ Each key in `kms.keys` requires:
 - `kms_id`: KMS key ID or alias (e.g., `alias/my-key` or full ARN)
 - `gpg_fingerprint`: The GPG fingerprint to embed in signatures (40 hex chars)
 
+### Fetching GPG passphrases from Bitwarden
+
+Instead of typing GPG key passphrases interactively (or setting
+`SF_PASS_DB_DEV_PASS` for development), the service can pull them from a
+Bitwarden vault at startup using
+[py-bitwarden-wrapper](https://github.com/AlmaLinux/py-bitwarden-wrapper).
+
+**Requirements:**
+1. The Bitwarden CLI (`bw`) must be installed and on `PATH`.
+2. Install the extra: `pip install ".[bitwarden]"`.
+3. For each GPG keyid listed in `SF_PGP_KEYS_ID` / `gpg.keys`, create a
+   Bitwarden login item whose **name equals the keyid** and whose
+   **password field** holds the passphrase.
+
+**Configuration (env):**
+
+```bash
+SF_BITWARDEN_ENABLED=True
+SF_BITWARDEN_USERNAME=signer@example.com
+# Either a master password env var...
+SF_BITWARDEN_PASSWORD="..."
+# ...or a path to a file containing it:
+SF_BITWARDEN_PASSWORD_FILE=/run/secrets/bw_master
+# Optional: restrict lookup to one collection
+SF_BITWARDEN_COLLECTION_ID=<uuid>
+```
+
+**Configuration (YAML):**
+
+```yaml
+bitwarden:
+  enabled: true
+  username: signer@example.com
+  password_file: /run/secrets/bw_master
+  collection_id: <uuid>
+```
+
+If `bitwarden.enabled` is true, fetched passphrases take precedence over
+both interactive prompts and `SF_PASS_DB_DEV_PASS`. Startup fails fast if
+any keyid is missing from the vault or its passphrase does not unlock the
+GPG key.
+
 ### Database initialization
 
 #### Database Configuration

--- a/README.md
+++ b/README.md
@@ -208,6 +208,17 @@ Settings are loaded in this order (highest priority first):
 
 This allows keeping secrets (like `SF_JWT_SECRET_KEY`) in environment variables while having the rest in the YAML file.
 
+**Settings with no YAML equivalent (environment-only):**
+
+A few settings are read only from environment variables — they are ignored if
+placed in the YAML file:
+
+- `SF_PASS_DB_DEV_MODE` / `SF_PASS_DB_DEV_PASS` — development-mode passphrase
+  handling. Set these in the environment (or `.env`); there is no `config.yaml`
+  key for them.
+- `SF_HOST_GNUPG` — used only by `docker-compose.yml` to mount the host's
+  `.gnupg` directory; it is not a service setting.
+
 ### AWS KMS Backend Setup
 
 The KMS backend produces PGP-compatible signatures that can be verified with standard `gpg --verify` commands.
@@ -322,13 +333,23 @@ bitwarden:
   enabled: true
   username: signer@example.com
   password_file: /run/secrets/bw_master
-  collection_id: <uuid>
+  # collection_id: <uuid>   # optional — see note below
 ```
+
+`collection_id` is **optional**. If omitted, the whole vault is searched for
+items matching each keyid. If provided, it must be a real Bitwarden collection
+UUID — a placeholder string will make the lookup fail (it is passed straight to
+`bw list items --collectionid`). Either leave it out or set a valid UUID.
 
 If `bitwarden.enabled` is true, fetched passphrases take precedence over
 both interactive prompts and `SF_PASS_DB_DEV_PASS`. Startup fails fast if
 any keyid is missing from the vault or its passphrase does not unlock the
 GPG key.
+
+> **Note:** `bitwarden-wrapper` is not published on PyPI — the `[bitwarden]`
+> extra installs it directly from
+> [github.com/AlmaLinux/py-bitwarden-wrapper](https://github.com/AlmaLinux/py-bitwarden-wrapper).
+> The Bitwarden CLI (`bw`) must also be installed and on `PATH`.
 
 ### Database initialization
 

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,8 @@ setup(
             'boto3 >= 1.26.0',
             'PGPy13 >= 0.6.1rc1',
         ],
+        'bitwarden': [
+            'bitwarden-wrapper >= 0.1.16',
+        ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
             'PGPy13 >= 0.6.1rc1',
         ],
         'bitwarden': [
-            'bitwarden-wrapper >= 0.1.16',
+            'bitwarden-wrapper @ git+https://github.com/AlmaLinux/py-bitwarden-wrapper.git@0.1.17',
         ],
     },
 )

--- a/sign/config.py
+++ b/sign/config.py
@@ -179,6 +179,26 @@ class Settings(BaseSettings):
         ),
         env="SF_YUBIKEY_KEYIDS",
     )
+    bitwarden_enabled: bool = Field(
+        default=False,
+        description="fetch GPG key passphrases from Bitwarden",
+    )
+    bitwarden_username: Optional[str] = Field(
+        default=None,
+        description="Bitwarden account username/email",
+    )
+    bitwarden_password: Optional[str] = Field(
+        default=None,
+        description="Bitwarden master password (env-friendly)",
+    )
+    bitwarden_password_file: Optional[str] = Field(
+        default=None,
+        description="path to a file containing the Bitwarden master password",
+    )
+    bitwarden_collection_id: Optional[str] = Field(
+        default=None,
+        description="optional Bitwarden collection ID to restrict the lookup",
+    )
 
     def get_kms_key_ids(self) -> List[str]:
         """Get list of KMS key IDs from config."""
@@ -272,6 +292,19 @@ def create_settings() -> Settings:
         if 'keys' in kms:
             flat_config['kms_keys'] = kms['keys']
 
+    if 'bitwarden' in yaml_config:
+        bw = yaml_config['bitwarden']
+        if 'enabled' in bw:
+            flat_config['bitwarden_enabled'] = bw['enabled']
+        if 'username' in bw:
+            flat_config['bitwarden_username'] = bw['username']
+        if 'password' in bw:
+            flat_config['bitwarden_password'] = bw['password']
+        if 'password_file' in bw:
+            flat_config['bitwarden_password_file'] = bw['password_file']
+        if 'collection_id' in bw:
+            flat_config['bitwarden_collection_id'] = bw['collection_id']
+
     if 'max_upload_bytes' in yaml_config:
         flat_config['max_upload_bytes'] = yaml_config['max_upload_bytes']
     if 'tmp_dir' in yaml_config:
@@ -309,6 +342,11 @@ def create_settings() -> Settings:
         'SF_KMS_MAX_WORKERS': 'kms_max_workers',
         'SF_PASS_DB_DEV_MODE': 'pass_db_dev_mode',
         'SF_PASS_DB_DEV_PASS': 'pass_db_dev_pass',
+        'SF_BITWARDEN_ENABLED': 'bitwarden_enabled',
+        'SF_BITWARDEN_USERNAME': 'bitwarden_username',
+        'SF_BITWARDEN_PASSWORD': 'bitwarden_password',
+        'SF_BITWARDEN_PASSWORD_FILE': 'bitwarden_password_file',
+        'SF_BITWARDEN_COLLECTION_ID': 'bitwarden_collection_id',
     }
 
     for env_var, field_name in env_mapping.items():

--- a/sign/pgp/bitwarden.py
+++ b/sign/pgp/bitwarden.py
@@ -1,0 +1,63 @@
+"""Fetch GPG key passphrases from a Bitwarden vault.
+
+Each GPG keyid must correspond to a Bitwarden item whose *name* equals the
+keyid and whose *password* field is the passphrase.
+"""
+import logging
+from typing import Dict, List, Optional
+
+from sign.pgp.errors import ConfigurationError
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_passphrases(
+    keyids: List[str],
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    password_file: Optional[str] = None,
+    collection_id: Optional[str] = None,
+) -> Dict[str, str]:
+    try:
+        from bsbw import BWCLIWrapper
+    except ImportError as e:
+        raise ConfigurationError(
+            "bitwarden-wrapper is not installed. "
+            "Install with: pip install '.[bitwarden]'"
+        ) from e
+
+    if not password and not password_file:
+        raise ConfigurationError(
+            "Bitwarden master password or password file must be provided "
+            "(set bitwarden.password / SF_BITWARDEN_PASSWORD or "
+            "bitwarden.password_file / SF_BITWARDEN_PASSWORD_FILE)"
+        )
+
+    logger.info("Fetching GPG passphrases from Bitwarden for %d keys", len(keyids))
+    wrapper = BWCLIWrapper(
+        username=username,
+        password=password,
+        password_file=password_file,
+        collection_id=collection_id,
+    )
+    container = wrapper.get_secrets()
+
+    result: Dict[str, str] = {}
+    missing: List[str] = []
+    for keyid in keyids:
+        if keyid not in container:
+            missing.append(keyid)
+            continue
+        passphrase = container.get_credentials(keyid, password_only=True)
+        if not passphrase:
+            missing.append(keyid)
+            continue
+        result[keyid] = passphrase
+
+    if missing:
+        raise ConfigurationError(
+            "Bitwarden vault is missing passphrases for keys: "
+            + ", ".join(missing)
+        )
+
+    return result

--- a/sign/pgp/bitwarden.py
+++ b/sign/pgp/bitwarden.py
@@ -19,7 +19,7 @@ def fetch_passphrases(
     collection_id: Optional[str] = None,
 ) -> Dict[str, str]:
     try:
-        from bsbw import BWCLIWrapper
+        from bsbw.wrapper import BWCLIWrapper
     except ImportError as e:
         raise ConfigurationError(
             "bitwarden-wrapper is not installed. "

--- a/sign/pgp/pgp.py
+++ b/sign/pgp/pgp.py
@@ -34,10 +34,12 @@ class PGP:
         pass_db_dev_mode: bool = False,
         pass_db_dev_pass: str = None,
         tmp_dir: str = '/tmp',
+        preloaded_passwords: dict = None,
     ):
         self.__gpg = gnupg.GPG(gpgbinary=gpg_binary, keyring=keyring)
         self.__pass_db = PGPPasswordDB(
-            self.__gpg, pgp_keys, pass_db_dev_mode, pass_db_dev_pass
+            self.__gpg, pgp_keys, pass_db_dev_mode, pass_db_dev_pass,
+            preloaded_passwords=preloaded_passwords,
         )
         self.max_upload_bytes = max_upload_bytes
         self.tmp_dir = tmp_dir

--- a/sign/pgp/pgp_password_db.py
+++ b/sign/pgp/pgp_password_db.py
@@ -1,5 +1,8 @@
 import getpass
+from typing import Dict, Optional
+
 import gnupg
+
 from sign.pgp.errors import ConfigurationError
 from sign.pgp.helpers import verify_pgp_key_password
 
@@ -7,7 +10,8 @@ from sign.pgp.helpers import verify_pgp_key_password
 class PGPPasswordDB(object):
     def __init__(self, gpg: gnupg.GPG, pgp_keys: list[str],
                  development_mode: bool = False,
-                 development_password: str = None):
+                 development_password: str = None,
+                 preloaded_passwords: Optional[Dict[str, str]] = None):
         """
         Password DB initialization.
         This structure stores GPG keys passwords
@@ -16,8 +20,16 @@ class PGPPasswordDB(object):
         ----------
         gpg : gnupg.GPG
             Gpg wrapper.
-        keyids : list of str
+        pgp_keys : list of str
             List of PGP keyids.
+        development_mode : bool
+            If True, use ``development_password`` for every key.
+        development_password : str
+            Single passphrase to use in development mode.
+        preloaded_passwords : dict, optional
+            Mapping of keyid -> passphrase fetched from an external source
+            (e.g. Bitwarden). Takes precedence over ``development_mode`` and
+            interactive prompting.
         """
         self.__gpg = gpg
         self.__keys = {keyid: {'password': ''} for keyid in pgp_keys}
@@ -27,16 +39,19 @@ class PGPPasswordDB(object):
                                      'mode')
         self.__development_mode = development_mode
         self.__development_password = development_password
+        self.__preloaded_passwords = preloaded_passwords or {}
 
     def ask_for_passwords(self):
         """
-        Asks a user for PGP private key passwords and stores them in the DB.
+        Populates the DB with PGP private key passphrases.
 
-        RaisesF
+        Source precedence: preloaded passwords (e.g. Bitwarden) >
+        development mode > interactive prompt.
+
+        Raises
         ------
-        castor.errors.ConfigurationError
-            If a private GPG key is not found or an entered password is
-            incorrect.
+        sign.pgp.errors.ConfigurationError
+            If a private GPG key is not found or a passphrase is incorrect.
         """
         existent_keys = {key["keyid"]: key
                          for key in self.__gpg.list_keys(True)}
@@ -47,7 +62,9 @@ class PGPPasswordDB(object):
                     "PGP key {0} is not found in the gnupg2 database "
                     "available keys {1}".format(keyid, str(existent_keys.keys()))
                 )
-            if self.__development_mode:
+            if keyid in self.__preloaded_passwords:
+                password = self.__preloaded_passwords[keyid]
+            elif self.__development_mode:
                 password = self.__development_password
             else:
                 password = getpass.getpass('\nPlease enter the {0} PGP key '
@@ -63,49 +80,10 @@ class PGPPasswordDB(object):
             ]
 
     def get_password(self, keyid):
-        """
-        Returns a password for the specified private PGP key.
-
-        Parameters
-        ----------
-        keyid : str
-            Private PGP key keyid.
-
-        Returns
-        -------
-        str
-            Password.
-        """
         return self.__keys[keyid]["password"]
 
     def get_fingerprint(self, keyid):
-        """
-        Returns a fingerprint for the specified private PGP key.
-
-        Parameters
-        ----------
-        keyid : str
-            Private PGP key keyid.
-
-        Returns
-        -------
-        str
-            fingerprint.
-        """
         return self.__keys[keyid]["fingerprint"]
 
     def get_subkeys(self, keyid):
-        """
-        Returns a list of subkey fingerprints.
-
-        Parameters
-        ----------
-        keyid : str
-            Private PGP key keyid.
-
-        Returns
-        -------
-        list
-            Subkey fingerprints.
-        """
         return self.__keys[keyid]["subkeys"]

--- a/sign/signing/backend.py
+++ b/sign/signing/backend.py
@@ -51,6 +51,18 @@ def get_signing_backend() -> SigningBackend:
     if backend_type == 'gpg':
         from sign.pgp import PGP
 
+        preloaded_passwords = None
+        if settings.bitwarden_enabled:
+            from sign.pgp.bitwarden import fetch_passphrases
+
+            preloaded_passwords = fetch_passphrases(
+                keyids=settings.pgp_keys,
+                username=settings.bitwarden_username,
+                password=settings.bitwarden_password,
+                password_file=settings.bitwarden_password_file,
+                collection_id=settings.bitwarden_collection_id,
+            )
+
         _backend_instance = GPGAdapter(
             PGP(
                 keyring=settings.keyring,
@@ -60,6 +72,7 @@ def get_signing_backend() -> SigningBackend:
                 pass_db_dev_pass=settings.pass_db_dev_pass,
                 max_upload_bytes=settings.max_upload_bytes,
                 tmp_dir=settings.tmp_dir,
+                preloaded_passwords=preloaded_passwords,
             )
         )
         logging.info("Using GPG signing backend")

--- a/tests/pgp/bitwarden_test.py
+++ b/tests/pgp/bitwarden_test.py
@@ -1,0 +1,115 @@
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from sign.pgp.errors import ConfigurationError
+
+
+KEY_A = "AAAA1111BBBB2222"
+KEY_B = "CCCC3333DDDD4444"
+
+
+class FakeContainer:
+    def __init__(self, mapping):
+        self._mapping = mapping
+
+    def __contains__(self, item):
+        return item in self._mapping
+
+    def get_credentials(self, name, password_only=False):
+        value = self._mapping[name]
+        return value if password_only else (None, value)
+
+
+@pytest.fixture
+def fake_bsbw(monkeypatch):
+    """Install a stub `bsbw` module so the fetcher can import it."""
+    module = types.ModuleType("bsbw")
+    module.BWCLIWrapper = MagicMock()
+    monkeypatch.setitem(sys.modules, "bsbw", module)
+    yield module
+
+
+def _import_fetcher():
+    # Import after the stub is in place so the deferred import inside the
+    # function picks up the fake module.
+    from sign.pgp.bitwarden import fetch_passphrases
+    return fetch_passphrases
+
+
+def test_fetch_passphrases_returns_keyid_map(fake_bsbw):
+    fake_bsbw.BWCLIWrapper.return_value.get_secrets.return_value = (
+        FakeContainer({KEY_A: "secret-a", KEY_B: "secret-b"})
+    )
+
+    fetch_passphrases = _import_fetcher()
+    result = fetch_passphrases(
+        keyids=[KEY_A, KEY_B], password="master"
+    )
+
+    assert result == {KEY_A: "secret-a", KEY_B: "secret-b"}
+    fake_bsbw.BWCLIWrapper.assert_called_once_with(
+        username=None,
+        password="master",
+        password_file=None,
+        collection_id=None,
+    )
+
+
+def test_fetch_passphrases_passes_collection_and_password_file(fake_bsbw):
+    fake_bsbw.BWCLIWrapper.return_value.get_secrets.return_value = (
+        FakeContainer({KEY_A: "x"})
+    )
+
+    fetch_passphrases = _import_fetcher()
+    fetch_passphrases(
+        keyids=[KEY_A],
+        username="signer@example.com",
+        password_file="/tmp/bw_master",
+        collection_id="col-1",
+    )
+
+    fake_bsbw.BWCLIWrapper.assert_called_once_with(
+        username="signer@example.com",
+        password=None,
+        password_file="/tmp/bw_master",
+        collection_id="col-1",
+    )
+
+
+def test_fetch_passphrases_requires_master_credential(fake_bsbw):
+    fetch_passphrases = _import_fetcher()
+    with pytest.raises(ConfigurationError, match="master password"):
+        fetch_passphrases(keyids=[KEY_A])
+    fake_bsbw.BWCLIWrapper.assert_not_called()
+
+
+def test_fetch_passphrases_missing_item_raises(fake_bsbw):
+    fake_bsbw.BWCLIWrapper.return_value.get_secrets.return_value = (
+        FakeContainer({KEY_A: "secret-a"})
+    )
+
+    fetch_passphrases = _import_fetcher()
+    with pytest.raises(ConfigurationError, match=KEY_B):
+        fetch_passphrases(keyids=[KEY_A, KEY_B], password="m")
+
+
+def test_fetch_passphrases_empty_passphrase_treated_as_missing(fake_bsbw):
+    fake_bsbw.BWCLIWrapper.return_value.get_secrets.return_value = (
+        FakeContainer({KEY_A: ""})
+    )
+
+    fetch_passphrases = _import_fetcher()
+    with pytest.raises(ConfigurationError, match=KEY_A):
+        fetch_passphrases(keyids=[KEY_A], password="m")
+
+
+def test_fetch_passphrases_without_bsbw_installed(monkeypatch):
+    # Ensure bsbw cannot be imported.
+    monkeypatch.setitem(sys.modules, "bsbw", None)
+
+    from sign.pgp.bitwarden import fetch_passphrases
+    with pytest.raises(ConfigurationError, match="bitwarden-wrapper"):
+        fetch_passphrases(keyids=[KEY_A], password="m")

--- a/tests/pgp/bitwarden_test.py
+++ b/tests/pgp/bitwarden_test.py
@@ -25,11 +25,18 @@ class FakeContainer:
 
 @pytest.fixture
 def fake_bsbw(monkeypatch):
-    """Install a stub `bsbw` module so the fetcher can import it."""
-    module = types.ModuleType("bsbw")
-    module.BWCLIWrapper = MagicMock()
-    monkeypatch.setitem(sys.modules, "bsbw", module)
-    yield module
+    """Install a stub `bsbw.wrapper` module so the fetcher can import it.
+
+    Mirrors the real package layout: ``BWCLIWrapper`` lives in
+    ``bsbw.wrapper`` and is not re-exported from the package root.
+    """
+    package = types.ModuleType("bsbw")
+    wrapper = types.ModuleType("bsbw.wrapper")
+    wrapper.BWCLIWrapper = MagicMock()
+    package.wrapper = wrapper
+    monkeypatch.setitem(sys.modules, "bsbw", package)
+    monkeypatch.setitem(sys.modules, "bsbw.wrapper", wrapper)
+    yield wrapper
 
 
 def _import_fetcher():
@@ -107,8 +114,10 @@ def test_fetch_passphrases_empty_passphrase_treated_as_missing(fake_bsbw):
 
 
 def test_fetch_passphrases_without_bsbw_installed(monkeypatch):
-    # Ensure bsbw cannot be imported.
+    # Ensure bsbw cannot be imported (block both the package and the
+    # submodule the fetcher imports from).
     monkeypatch.setitem(sys.modules, "bsbw", None)
+    monkeypatch.setitem(sys.modules, "bsbw.wrapper", None)
 
     from sign.pgp.bitwarden import fetch_passphrases
     with pytest.raises(ConfigurationError, match="bitwarden-wrapper"):


### PR DESCRIPTION
Integrates py-bitwarden-wrapper as an optional source for GPG key passphrases. When SF_BITWARDEN_ENABLED is set, the service looks up each configured keyid as a Bitwarden item name and uses its password field as the passphrase, taking precedence over interactive prompts and dev-mode.

Resolves: https://github.com/AlmaLinux/build-system/issues/280