### PR TITLE
fix: initialize signing backend at startup via lifespan handler

### DIFF
--- a/sign/app.py
+++ b/sign/app.py
@@ -1,9 +1,11 @@
 import logging
 import sys
+from contextlib import asynccontextmanager
 
 import sentry_sdk
 from fastapi import FastAPI
 
+from sign.api.dependencies import get_backend
 from sign.api.routes import router
 from sign.config import settings
 from sign.db.helpers import db_is_connected
@@ -25,27 +27,39 @@ if settings.sentry_dsn:
         ],
     )
 
-app = FastAPI(root_path=settings.root_url)
-app.include_router(router)
 
-
-@app.on_event("startup")
-async def startup_event():
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
     """
-    Verify database connectivity on application startup.
+    Application startup/shutdown handler.
+
+    On startup it verifies database connectivity and eagerly initializes the
+    signing backend. Initializing the backend here, before the server starts
+    accepting requests, ensures the GPG passphrase prompt
+    (``PGPPasswordDB.ask_for_passwords``) runs while the process is still
+    attached to the controlling terminal, instead of being deferred to the
+    first ``/sign`` request.
     """
     logger.info("Checking database connection...")
-    db_health = db_is_connected()
-    if db_health:
-        logger.info("Database connection successful")
-        return
-    logger.error(
-        "Database connection failed!\n"
-        "Please check:\n"
-        "\t1. Database server is running\n"
-        "\t2. Connection credentials are correct\n"
-        "\t3. Database exists and is accessible\n"
-        "\t4. Network connectivity to database\n"
-        "Application startup failed due to database connectivity issues"
-    )
-    sys.exit(1)
+    if not db_is_connected():
+        logger.error(
+            "Database connection failed!\n"
+            "Please check:\n"
+            "\t1. Database server is running\n"
+            "\t2. Connection credentials are correct\n"
+            "\t3. Database exists and is accessible\n"
+            "\t4. Network connectivity to database\n"
+            "Application startup failed due to database connectivity issues"
+        )
+        sys.exit(1)
+    logger.info("Database connection successful")
+
+    logger.info("Initializing signing backend...")
+    get_backend()
+    logger.info("Signing backend initialized")
+
+    yield
+
+
+app = FastAPI(root_path=settings.root_url, lifespan=lifespan)
+app.include_router(router)


### PR DESCRIPTION
The GPG backend was built lazily on the first /sign request, so the passphrase prompt (PGPPasswordDB.ask_for_passwords) never ran at startup and was deferred into an async request handler where getpass blocks the event loop.

Convert the deprecated @app.on_event("startup") hook to a lifespan context manager that eagerly calls get_backend() after the DB check, so the passphrase prompt runs before the server accepts requests while the process is still attached to the controlling terminal.