### PR TITLE
Fix logging errors from syslog handler in containerised deployments

### DIFF
--- a/sign/log.py
+++ b/sign/log.py
@@ -1,17 +1,28 @@
 import logging
 import logging.handlers
+import os
+import sys
+
 
 class SysLog:
 
     def __init__(self, tag_name: str, level: int = logging.INFO):
         self._tag_name = tag_name
-        self._logger = logging.getLogger()
         self._level = level
+        self._logger = logging.getLogger('sign.audit')
         self._logger.setLevel(self._level)
-        formatter = logging.Formatter(self._tag_name + ': %(message)s')
-        handler = logging.handlers.SysLogHandler(address='/dev/log')
-        handler.setFormatter(formatter)
-        self.logger.addHandler(handler)
+        self._logger.propagate = False
+
+        if not self._logger.handlers:
+            formatter = logging.Formatter(self._tag_name + ': %(message)s')
+            handlers: list[logging.Handler] = [logging.StreamHandler(sys.stdout)]
+            if os.path.exists('/dev/log'):
+                handlers.append(
+                    logging.handlers.SysLogHandler(address='/dev/log')
+                )
+            for handler in handlers:
+                handler.setFormatter(formatter)
+                self._logger.addHandler(handler)
 
     def sign_log(
         self,


### PR DESCRIPTION
'SysLogHandler' was attached to the root logger with a hardcoded
'/dev/log' path that doesn't exist in containers. This caused every
log line in the process to spam a 'Bad file descriptor' traceback.

Reproduced the exact traceback from the issue against the original code
in a Python container. Confirmed zero errors and clean audit records
with the fix.

- Use a dedicated 'sign.audit' logger instead of root
- Fall back to stdout when '/dev/log' isn't present 
  (on a native host with a real syslog socket, behaviour is unchanged)
- Matches how the KMS backend already handles its audit logging

Fixes https://github.com/AlmaLinux/build-system/issues/446