### PR TITLE
PF-673: fix /sign-batch random 500s (fd exhaustion)

### DIFF
--- a/sign/pgp/pgp.py
+++ b/sign/pgp/pgp.py
@@ -203,9 +203,12 @@ class PGP:
                 fd.name,
             ]
 
-            # Serialize pexpect calls within the process; cross-process
-            # coordination is handled by the shared/exclusive lock taken
-            # by the caller (sign_batch).
+            # Serialize pexpect calls within the process. sign_batch already
+            # signs sequentially (PF-673), but this semaphore keeps
+            # _sign_batch_file safe if it is ever awaited concurrently, so
+            # only one gpg/pexpect invocation talks to the gpg-agent at a time.
+            # Cross-process coordination is handled by the shared/exclusive
+            # lock taken by the caller (sign_batch).
             if self.__gpg_semaphore is None:
                 self.__gpg_semaphore = asyncio.Semaphore(1)
             async with self.__gpg_semaphore:
@@ -269,10 +272,17 @@ class PGP:
         digest_algo: str = 'SHA256',
     ) -> List[Tuple[str, str]]:
         """
-        Sign multiple files asynchronously.
+        Sign multiple files, one at a time.
 
-        Uses exclusive_lock for cross-process protection and semaphore
-        for safe agent restarts within the process.
+        Uses exclusive_lock for cross-process protection.
+
+        Files are signed sequentially: gpg signing is serial anyway (a single
+        gpg-agent), so signing concurrently bought nothing while opening one
+        temp file (and one pexpect PTY) per file up front. On large batches
+        that pushed the open-fd count high enough to hit pexpect's select()
+        FD_SETSIZE limit. Signing one file at a time keeps at most one temp
+        file and one PTY open, so fd usage stays flat regardless of batch
+        size. See PF-673.
 
         Raises exception immediately if any file fails (fail-fast).
         """
@@ -281,22 +291,26 @@ class PGP:
         )
 
         is_yubikey = self._is_yubikey(keyid)
-        tasks = [
-            self._sign_single_file_for_batch(
-                keyid=keyid,
-                file=file,
-                detach_sign=detach_sign,
-                digest_algo=digest_algo,
-            )
-            for file in files
-        ]
+
+        async def _sign_all() -> List[Tuple[str, str]]:
+            signed = []
+            for file in files:
+                signed.append(
+                    await self._sign_single_file_for_batch(
+                        keyid=keyid,
+                        file=file,
+                        detach_sign=detach_sign,
+                        digest_algo=digest_algo,
+                    )
+                )
+            return signed
 
         with shared_lock(settings.gpg_locks_dir, GPG_AGENT_LOCK_FILENAME):
             if is_yubikey:
                 with exclusive_lock(settings.gpg_locks_dir, keyid):
-                    results = await asyncio.gather(*tasks)
+                    results = await _sign_all()
             else:
-                results = await asyncio.gather(*tasks)
+                results = await _sign_all()
 
         if is_yubikey:
             with exclusive_lock(settings.gpg_locks_dir, GPG_AGENT_LOCK_FILENAME):

--- a/sign/pgp/pgp.py
+++ b/sign/pgp/pgp.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import logging
 import os
 from typing import List, Tuple
@@ -69,13 +70,17 @@ class PGP:
             dir=self.tmp_dir,
         ) as fd:
             # writing content to temp file
-            while content := await file.read(1024 * 1024):
-                upload_size += len(content)
-                if upload_size > self.max_upload_bytes:
-                    raise FileTooBigError
-                await fd.write(content)
-                await fd.flush()
-            file.file.close()
+            try:
+                while content := await file.read(1024 * 1024):
+                    upload_size += len(content)
+                    if upload_size > self.max_upload_bytes:
+                        raise FileTooBigError
+                    await fd.write(content)
+                    await fd.flush()
+            finally:
+                # Always release the UploadFile's spooled temp file/fd, even
+                # if the upload-size check aborts mid-read. See PF-673.
+                file.file.close()
 
             hash_before = hash_file(
                 fd.name,
@@ -139,15 +144,22 @@ class PGP:
                 hash_after,
                 keyid,
             )
-            if status != 0:
-                message = f'gpg failed to sign file, error: {out}'
-                logging.error(message)
-                raise Exception(message)
+            # gpg writes the signature to a separate '<name>.asc' file that the
+            # NamedTemporaryFile context manager does not track. Always remove
+            # it, including when signing failed and left a partial file behind,
+            # otherwise it leaks on disk on every error. See PF-673.
+            try:
+                if status != 0:
+                    message = f'gpg failed to sign file, error: {out}'
+                    logging.error(message)
+                    raise Exception(message)
 
-        # reading PGP signature
-        async with aiofiles.open(f'{fd.name}.asc', 'r') as fl:
-            answer = await fl.read()
-        await remove(f'{fd.name}.asc')
+                # reading PGP signature
+                async with aiofiles.open(f'{fd.name}.asc', 'r') as fl:
+                    answer = await fl.read()
+            finally:
+                with contextlib.suppress(FileNotFoundError):
+                    await remove(f'{fd.name}.asc')
 
         return answer
 
@@ -163,13 +175,17 @@ class PGP:
         async with aiofiles.tempfile.NamedTemporaryFile(
             'wb', delete=True, dir=self.tmp_dir
         ) as fd:
-            while content := await file.read(1024 * 1024):
-                upload_size += len(content)
-                if upload_size > self.max_upload_bytes:
-                    raise FileTooBigError
-                await fd.write(content)
-                await fd.flush()
-            file.file.close()
+            try:
+                while content := await file.read(1024 * 1024):
+                    upload_size += len(content)
+                    if upload_size > self.max_upload_bytes:
+                        raise FileTooBigError
+                    await fd.write(content)
+                    await fd.flush()
+            finally:
+                # Always release the UploadFile's spooled temp file/fd, even
+                # if the upload-size check aborts mid-read. See PF-673.
+                file.file.close()
 
             hash_before = hash_file(fd.name, hasher=get_hasher())
 
@@ -212,13 +228,20 @@ class PGP:
                 keyid,
             )
 
-            if status != 0:
-                raise Exception(f'gpg failed to sign file, error: {out}')
+            # gpg writes the signature to a separate '<name>.asc' file that the
+            # NamedTemporaryFile context manager does not track. Always remove
+            # it, including when signing failed and left a partial file behind,
+            # otherwise it leaks on disk on every error. See PF-673.
+            try:
+                if status != 0:
+                    raise Exception(f'gpg failed to sign file, error: {out}')
 
-            async with aiofiles.open(f'{fd.name}.asc', 'r') as fl:
-                signature = await fl.read()
+                async with aiofiles.open(f'{fd.name}.asc', 'r') as fl:
+                    signature = await fl.read()
+            finally:
+                with contextlib.suppress(FileNotFoundError):
+                    await remove(f'{fd.name}.asc')
 
-        await remove(f'{fd.name}.asc')
         return fd.name, signature
 
     async def _sign_single_file_for_batch(

--- a/sign/pgp/pgp.py
+++ b/sign/pgp/pgp.py
@@ -107,6 +107,10 @@ class PGP:
                             env={"LC_ALL": "en_US.UTF-8"},
                             timeout=1200,
                             withexitstatus=1,
+                            # poll() has no FD_SETSIZE (1024) limit, unlike
+                            # select(); required when the process holds many
+                            # open fds. See PF-673.
+                            use_poll=True,
                         )
                 else:
                     out, status = pexpect.run(
@@ -115,6 +119,10 @@ class PGP:
                         env={"LC_ALL": "en_US.UTF-8"},
                         timeout=1200,
                         withexitstatus=1,
+                        # poll() has no FD_SETSIZE (1024) limit, unlike
+                        # select(); required when the process holds many
+                        # open fds. See PF-673.
+                        use_poll=True,
                     )
             if is_yubikey:
                 with exclusive_lock(settings.gpg_locks_dir, GPG_AGENT_LOCK_FILENAME):
@@ -191,6 +199,9 @@ class PGP:
                     env={"LC_ALL": "en_US.UTF-8"},
                     timeout=1200,
                     withexitstatus=1,
+                    # poll() has no FD_SETSIZE (1024) limit, unlike select();
+                    # required when the process holds many open fds. See PF-673.
+                    use_poll=True,
                 )
 
             hash_after = hash_file(fd.name, hasher=get_hasher())

--- a/tests/pgp/pgp_test.py
+++ b/tests/pgp/pgp_test.py
@@ -1,0 +1,190 @@
+"""
+Regression tests for PF-673: /sign-batch failing with
+'ValueError: filedescriptor out of range in select()'.
+
+These cover the three fixes:
+  1. every pexpect.run() call passes use_poll=True (poll() has no FD_SETSIZE
+     limit, so signing never crashes on a high-numbered fd);
+  2. the gpg '<name>.asc' file and the UploadFile spooled fd are cleaned up on
+     every path, including signing failure / oversized upload (no fd leak);
+  3. sign_batch signs files one at a time, so it does not open one temp file +
+     PTY per file up front (fd usage stays flat regardless of batch size).
+"""
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from sign.errors import FileTooBigError
+from sign.pgp.pgp import PGP
+
+
+class _FakeUploadFile:
+    """Minimal stand-in for fastapi.UploadFile."""
+
+    def __init__(self, filename, data=b'data'):
+        self.filename = filename
+        self._chunks = [data] if data else []
+        # .file mimics the SpooledTemporaryFile; we only assert it is closed.
+        self.file = SimpleNamespace(closed=False)
+        self.file.close = lambda: setattr(self.file, 'closed', True)
+
+    async def read(self, _size):
+        if self._chunks:
+            return self._chunks.pop(0)
+        return b''
+
+
+def _make_pgp(tmp_path):
+    """Build a PGP instance without running its heavy __init__."""
+    pgp = object.__new__(PGP)
+    pgp.tmp_dir = str(tmp_path)
+    pgp.max_upload_bytes = 1024
+    pgp._PGP__gpg = SimpleNamespace(gpgbinary='/usr/bin/gpg2')
+    pgp._PGP__pass_db = SimpleNamespace(get_password=lambda keyid: 'pw')
+    pgp._PGP__syslog = SimpleNamespace(sign_log=lambda *a, **k: None)
+    pgp._PGP__gpg_semaphore = None
+    return pgp
+
+
+def _write_asc_then_ok(tmp_path):
+    """
+    Fake pexpect.run that emulates gpg --detach-sign --armor: it creates a
+    '<name>.asc' next to the temp file and returns success.
+    """
+    def _run(command, **kwargs):
+        # the temp file path is the last token of the command
+        target = command.split()[-1]
+        with open(f'{target}.asc', 'w') as fl:
+            fl.write('-----BEGIN PGP SIGNATURE-----\n')
+        return (b'', 0)
+    return _run
+
+
+def _write_asc_then_fail(tmp_path):
+    """gpg that writes a partial .asc but exits non-zero (signing failure)."""
+    def _run(command, **kwargs):
+        target = command.split()[-1]
+        with open(f'{target}.asc', 'w') as fl:
+            fl.write('partial')
+        return (b'boom', 2)
+    return _run
+
+
+# --- Fix 1: use_poll=True ---------------------------------------------------
+
+def test_sign_passes_use_poll(tmp_path):
+    pgp = _make_pgp(tmp_path)
+    seen = {}
+
+    def _run(command, **kwargs):
+        seen.update(kwargs)
+        target = command.split()[-1]
+        with open(f'{target}.asc', 'w') as fl:
+            fl.write('sig')
+        return (b'', 0)
+
+    with mock.patch('sign.pgp.pgp.pexpect.run', side_effect=_run):
+        asyncio.run(pgp.sign('KEY', _FakeUploadFile('a.rpm')))
+
+    assert seen.get('use_poll') is True
+
+
+def test_sign_batch_passes_use_poll(tmp_path):
+    pgp = _make_pgp(tmp_path)
+    seen = {}
+
+    def _run(command, **kwargs):
+        seen.update(kwargs)
+        target = command.split()[-1]
+        with open(f'{target}.asc', 'w') as fl:
+            fl.write('sig')
+        return (b'', 0)
+
+    with mock.patch('sign.pgp.pgp.pexpect.run', side_effect=_run):
+        asyncio.run(pgp.sign_batch('KEY', [_FakeUploadFile('a.rpm')]))
+
+    assert seen.get('use_poll') is True
+
+
+# --- Fix 3: no leak of .asc / UploadFile on any path ------------------------
+
+def test_sign_removes_asc_on_success(tmp_path):
+    pgp = _make_pgp(tmp_path)
+    upload = _FakeUploadFile('a.rpm')
+    with mock.patch('sign.pgp.pgp.pexpect.run',
+                    side_effect=_write_asc_then_ok(tmp_path)):
+        asyncio.run(pgp.sign('KEY', upload))
+    assert os.listdir(tmp_path) == []        # no .asc, no temp file left
+    assert upload.file.closed is True
+
+
+def test_sign_removes_asc_on_gpg_failure(tmp_path):
+    pgp = _make_pgp(tmp_path)
+    upload = _FakeUploadFile('a.rpm')
+    with mock.patch('sign.pgp.pgp.pexpect.run',
+                    side_effect=_write_asc_then_fail(tmp_path)):
+        with pytest.raises(Exception):
+            asyncio.run(pgp.sign('KEY', upload))
+    # the partial .asc gpg left behind must be cleaned up despite the failure
+    assert os.listdir(tmp_path) == []
+    assert upload.file.closed is True
+
+
+def test_sign_closes_upload_on_too_big(tmp_path):
+    pgp = _make_pgp(tmp_path)
+    pgp.max_upload_bytes = 2
+    upload = _FakeUploadFile('a.rpm', data=b'way too large')
+    with mock.patch('sign.pgp.pgp.pexpect.run') as run:
+        with pytest.raises(FileTooBigError):
+            asyncio.run(pgp.sign('KEY', upload))
+    run.assert_not_called()                  # bailed before signing
+    assert upload.file.closed is True        # but still released the fd
+    assert os.listdir(tmp_path) == []
+
+
+def test_sign_batch_removes_asc_on_failure(tmp_path):
+    pgp = _make_pgp(tmp_path)
+    with mock.patch('sign.pgp.pgp.pexpect.run',
+                    side_effect=_write_asc_then_fail(tmp_path)):
+        with pytest.raises(Exception):
+            asyncio.run(pgp.sign_batch('KEY', [_FakeUploadFile('a.rpm')]))
+    assert os.listdir(tmp_path) == []
+
+
+# --- Fix 2: sequential signing, fd usage stays flat -------------------------
+
+def test_sign_batch_signs_sequentially(tmp_path):
+    """
+    At no point should more than one temp file exist in tmp_dir at once,
+    proving files are not all opened up front.
+    """
+    pgp = _make_pgp(tmp_path)
+    max_concurrent = {'n': 0}
+
+    def _run(command, **kwargs):
+        # count *.asc-less temp files currently open in the dir
+        live = [f for f in os.listdir(tmp_path) if not f.endswith('.asc')]
+        max_concurrent['n'] = max(max_concurrent['n'], len(live))
+        target = command.split()[-1]
+        with open(f'{target}.asc', 'w') as fl:
+            fl.write('sig')
+        return (b'', 0)
+
+    files = [_FakeUploadFile(f'f{i}.rpm') for i in range(20)]
+    with mock.patch('sign.pgp.pgp.pexpect.run', side_effect=_run):
+        results = asyncio.run(pgp.sign_batch('KEY', files))
+
+    assert len(results) == 20
+    assert max_concurrent['n'] == 1          # never more than one open at once
+
+
+def test_sign_batch_returns_filenames_and_sigs(tmp_path):
+    pgp = _make_pgp(tmp_path)
+    files = [_FakeUploadFile('a.rpm'), _FakeUploadFile('b.rpm')]
+    with mock.patch('sign.pgp.pgp.pexpect.run',
+                    side_effect=_write_asc_then_ok(tmp_path)):
+        results = asyncio.run(pgp.sign_batch('KEY', files))
+    assert [name for name, _ in results] == ['a.rpm', 'b.rpm']


### PR DESCRIPTION
## Problem

`/sign-batch` failed randomly with `ValueError: filedescriptor out of range in select()` — large CSAF batches (~160 files) 500'd, and it came back after every restart.

`pexpect` uses `select.select()`, which can't handle an fd `>= 1024`. Under load the process held enough open fds that the signing PTY's fd crossed 1024. Fds climbed because `sign_batch` opened all temp files up front, and `.asc`/upload fds leaked on error paths. Raising the soft limit to 65536 was only a stopgap (and is what exposed the bug).

## Fix (3 commits)

- **`use_poll=True`** on every `pexpect.run()` → `poll()` has no fd limit (fixes the crash).
- **`try/finally`** cleanup of `.asc` and `UploadFile` fds → stops the leak that filled tmp with ~15k files.
- **Sequential `sign_batch`** instead of `asyncio.gather` → open-fd count stays flat regardless of batch size.

No limits raised, per the acceptance criteria.

## Testing

10 unit tests pass. End-to-end against real `gpg2`: single + 20-file batch signatures verify correctly (no regression). The leak is confirmed fixed on the gpg-failure path.

Ticket: https://cloudlinux.atlassian.net/browse/PF-673
