### PR TITLE
fix: fail loudly when no config source is provided

### DIFF
--- a/sign/config.py
+++ b/sign/config.py
@@ -206,6 +206,28 @@ def create_settings() -> Settings:
     3. Default values
     """
     config_file = os.environ.get('SF_CONFIG_FILE', CONFIG_FILE_DEFAULT)
+    config_explicit = 'SF_CONFIG_FILE' in os.environ
+    config_path = os.path.expanduser(config_file)
+    config_exists = os.path.exists(config_path)
+
+    # An explicitly requested config file that is missing is always an
+    # error (protects against typos in SF_CONFIG_FILE).
+    if config_explicit and not config_exists:
+        raise RuntimeError(
+            f"SF_CONFIG_FILE points to {config_path!r}, which does not exist."
+        )
+
+    # Refuse to start with no configuration source at all. Without this
+    # guard, db_url silently falls back to a local SQLite file
+    # (DB_URL_DEFAULT), so destructive db_manage.py operations and the
+    # service itself would run against the wrong database instead of failing.
+    if not config_exists and 'SF_DB_URL' not in os.environ:
+        raise RuntimeError(
+            f"No configuration provided: config file {config_path!r} does "
+            "not exist and SF_DB_URL is not set. Set SF_CONFIG_FILE to a "
+            "valid config path or provide SF_DB_URL explicitly."
+        )
+
     yaml_config = load_yaml_config(config_file)
 
     flat_config = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+
+# sign.config.create_settings() now refuses to load with no configuration
+# source (no config file and no SF_DB_URL), to avoid silently falling back to
+# a local SQLite database. The unit tests import sign.config transitively but
+# do not touch the database, so provide a throwaway in-memory URL before any
+# test module imports sign.config.
+os.environ.setdefault('SF_DB_URL', 'sqlite:///:memory:')


### PR DESCRIPTION
create_settings() silently fell back to DB_URL_DEFAULT (a local SQLite file) when no config file existed and SF_DB_URL was unset. This made db_manage.py operate on a throwaway database instead of the intended PostgreSQL DB with no error.

Now create_settings() raises if SF_CONFIG_FILE points to a missing file, or if no config file exists and SF_DB_URL is not set. Add tests/conftest.py to provide an in-memory SF_DB_URL so DB-agnostic unit tests still run.